### PR TITLE
Migrate to go mod; pin versions

### DIFF
--- a/cloud-watch/workers.go
+++ b/cloud-watch/workers.go
@@ -85,8 +85,10 @@ func NewRunnerInternal(journal Journal, repeater JournalRepeater, logger *Logger
 				now := time.Now().Unix()
 				if now-r.lastMetricTime > 120 {
 					now = r.lastMetricTime
-					r.logger.Info.Printf("Systemd CloudWatch: batches sent %d, idleCount %d,  emptyCount %d",
-						r.batchCounter, r.idleCounter, r.emptyCounter)
+                    if r.debug {
+                        r.logger.Info.Printf("Systemd CloudWatch: batches sent %d, idleCount %d,  emptyCount %d",
+                            r.batchCounter, r.idleCounter, r.emptyCounter)
+                    }
 				}
 				r.idleCounter++
 			},
@@ -129,7 +131,7 @@ func (r *Runner) readOneRecord() (*Record, bool, error) {
 	if err != nil {
 		return nil, false, err
 	} else if count > 0 {
-		if r.debug {
+		if r.debug { 
 			r.logger.Info.Println("No errors, reading log")
 		}
 		record, err := NewRecord(r.journal, r.logger, r.config)
@@ -138,7 +140,7 @@ func (r *Runner) readOneRecord() (*Record, bool, error) {
 			return nil, false, fmt.Errorf("error unmarshalling record: %v", err)
 		}
 		if r.debug {
-			r.logger.Info.Println("Read record", record)
+ r.logger.Info.Println("Read record", record)
 		}
 		return record, true, nil
 	} else {

--- a/cloud-watch/workers.go
+++ b/cloud-watch/workers.go
@@ -140,7 +140,7 @@ func (r *Runner) readOneRecord() (*Record, bool, error) {
 			return nil, false, fmt.Errorf("error unmarshalling record: %v", err)
 		}
 		if r.debug {
- r.logger.Info.Println("Read record", record)
+            r.logger.Info.Println("Read record", record)
 		}
 		return record, true, nil
 	} else {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/krestivo-kdinfotech/systemd-cloud-watch
+
+require (
+	github.com/advantageous/go-logback v0.0.0-20161215180304-6db19679ca3e // indirect
+	github.com/advantageous/go-qbit v0.0.0-20161215210724-936ec5f2e3c9
+	github.com/aws/aws-sdk-go v1.25.11
+	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
+	github.com/hashicorp/hcl v1.0.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,15 @@
+github.com/advantageous/go-logback v0.0.0-20161215180304-6db19679ca3e h1:zDwXL5E118a4JRyWUVVzGUg4zDXY2CfllYYu+B6Vgy8=
+github.com/advantageous/go-logback v0.0.0-20161215180304-6db19679ca3e/go.mod h1:pynxONZJ8msfhJ8u3t9OQZVPsn9i9AW4VW55zv9K9+I=
+github.com/advantageous/go-qbit v0.0.0-20161215210724-936ec5f2e3c9 h1:lEiUbe1qEufQw4LNKsT+76ZQyW7YAduILzXoM5A9WWo=
+github.com/advantageous/go-qbit v0.0.0-20161215210724-936ec5f2e3c9/go.mod h1:GxZGXJ9phUteP1gtCEXxhLHu5Lt/i5lP4qvbNAMLI2Y=
+github.com/aws/aws-sdk-go v1.25.11 h1:wUivbsVOH3LpHdC3Rl5i+FLHfg4sOmYgv4bvHe7+/Pg=
+github.com/aws/aws-sdk-go v1.25.11/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f h1:JOrtw2xFKzlg+cbHpyrpLDmnN1HqhBfnX7WDiW7eG2c=
+github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f h1:lBNOc5arjvs8E5mO2tbpBpLoyyu8B6e44T7hJy6potg=
+github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
+github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"flag"
-	jcw "github.com/advantageous/systemd-cloud-watch/cloud-watch"
+	jcw "github.com/krestivo-kdinfotech/systemd-cloud-watch/cloud-watch"
 	"os"
 )
 


### PR DESCRIPTION
The latest release of this package is currently broken (the most recent commit breaks it). This reverts the most recent commit and also moves to using `go mod` which allows us to pin the dependencies